### PR TITLE
[CHORE] Remove deprecation

### DIFF
--- a/addon/templates/components/adde-color-picker.hbs
+++ b/addon/templates/components/adde-color-picker.hbs
@@ -54,7 +54,7 @@
             classNames="adde-text-input"
             class=(if _isCustomColorInvalid 'is-invalid')
             placeholder="HEX code"
-            action="setCustomColor"
+            enter="setCustomColor"
             invalid=_isCustomColorInvalid
             data-test-custom-color-input=true
           }}


### PR DESCRIPTION
```DEPRECATION: Using '{{input action="setCustomColor"}}' ('@addepar/forms/templates/components/adde-color-picker.hbs' @ L52:C10) is deprecated. Please use '{{input enter="setCustomColor"}}' instead.```