### PR TITLE
[CHORE] Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Addepar/addepar-forms.svg?branch=master)](https://travis-ci.org/Addepar/addepar-forms)
+
 # addepar-forms
 
 This README outlines the details of collaborating on this Ember addon.
@@ -8,23 +10,23 @@ This README outlines the details of collaborating on this Ember addon.
 ember install @addepar/forms
 ```
 
-* `git clone <repository-url>` this repository
-* `cd addepar-forms`
-* `npm install`
+- `git clone <repository-url>` this repository
+- `cd addepar-forms`
+- `npm install`
 
 ## Running
 
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+- `ember serve`
+- Visit your app at [http://localhost:4200](http://localhost:4200).
 
 ## Running Tests
 
-* `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
+- `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
+- `ember test`
+- `ember test --server`
 
 ## Building
 
-* `ember build`
+- `ember build`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@addepar/forms",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": ["ember-addon"],
   "license": "MIT",
@@ -66,7 +66,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "6.* || >= 7.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
   },
   "publishConfig": {
     "@addepar:registry": "https://registry.npmjs.org/"
+  },
+  "resolutions": {
+    "ember-cli-page-object": "1.15.0-beta.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,9 +2864,10 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-page-object@^1.15.0-beta.3:
-  version "1.15.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.15.0-beta.3.tgz#e41f3a33e35a6717c507b1a4c13fc990950c7d35"
+ember-cli-page-object@1.15.0-beta.4, ember-cli-page-object@^1.15.0-beta.3:
+  version "1.15.0-beta.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.15.0-beta.4.tgz#80b42c3951d4723b394c9caa44a3eea83f09ecdb"
+  integrity sha512-k7tKqyYRjtOG1ljMqVTfW1nLEew4hqLZbjvf67gTxXTgn/w+rXhAnldrapsp1OuccfeCJLKjvJXUzo5MGYdHdQ==
   dependencies:
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
The build is failing because `ember-cli-page-object` 1.15.0 ( https://github.com/san650/ember-cli-page-object/releases/tag/v1.15.0 ) `includes support for RFC232 and RFC268 style tests. This mode is automatically enabled when you use new @ember/test-helpers's setupApplicationTest/setupRenderingTest.`

#13 fails because a dependency is not properly pinned and any new build would currently fail.

```
not ok 10 Chrome 76.0 - Integration | Component | color picker cell: Color cell renders with background color
    ---
        actual: >
            null
        stack: >
            Error: Must setup rendering context before attempting to interact with elements.
                at Object.getRootElement (http://localhost:7357/assets/test-support.js:8373:13)
                at getRootElement (http://localhost:7357/assets/test-support.js:11003:49)
                at ExecutionContext.getElements (http://localhost:7357/assets/test-support.js:12003:81)
                at ExecutionContext.findWithAssert (http://localhost:7357/assets/test-support.js:11988:25)
                at findElementWithAssert (http://localhost:7357/assets/test-support.js:12725:72)
                at Object.get (http://localhost:7357/assets/test-support.js:13253:58)
                at Object.style (http://localhost:7357/assets/test-support.js:1730:31)
                at Object.isColor (http://localhost:7357/assets/test-support.js:7233:19)
                at Object.<anonymous> (http://localhost:7357/assets/tests.js:182:20)
                at runTest (http://localhost:7357/assets/test-support.js:3723:30)
```

I'm pinning the dependency instead of migrating the tests ( https://travis-ci.org/Addepar/addepar-forms/builds/582967347 ) as the tests fail on Ember 1.13 ( https://travis-ci.org/Addepar/addepar-forms/jobs/582967349 )

```
not ok 10 Chrome 76.0 - adde-color-picker-cell: Color cell renders with background color
    ---
        actual: >
            null
        stack: >
            TypeError: owner.lookup is not a function
                at http://localhost:7357/assets/test-support.js:10017:32
                at tryCatch (http://localhost:7357/assets/vendor.js:67368:14)
                at invokeCallback (http://localhost:7357/assets/vendor.js:67383:15)
                at publish (http://localhost:7357/assets/vendor.js:67351:9)
                at http://localhost:7357/assets/vendor.js:43725:7
                at invoke (http://localhost:7357/assets/vendor.js:11245:16)
                at Queue.flush (http://localhost:7357/assets/vendor.js:11309:11)
                at DeferredActionQueues.flush (http://localhost:7357/assets/vendor.js:11110:17)
                at Backburner.end (http://localhost:7357/assets/vendor.js:10399:25)
                at http://localhost:7357/assets/vendor.js:10990:18
        message: >
            Promise rejected before "Color cell renders with background color": owner.lookup is not a function
```

Also update to node 8 and add Travis badge to README.